### PR TITLE
Fix missing request id in debug logs on gRPC timeout

### DIFF
--- a/src/yandex_ai_studio_sdk/_client.py
+++ b/src/yandex_ai_studio_sdk/_client.py
@@ -22,6 +22,7 @@ from ._retry import RETRY_KIND_METADATA_KEY, RetryKind, RetryPolicy
 from ._types.misc import PathLike, coerce_path
 from ._utils.http import HTTPServiceName, get_http_service_endpoint
 from ._utils.lock import LazyLock
+from ._utils.metadata import CLIENT_REQUEST_ID_METADATA_KEY
 from ._utils.proto import service_for_ctor
 
 
@@ -168,7 +169,7 @@ class AsyncCloudClient:
         timeout: float,
     ) -> list[tuple[str, str]]:
         headers = [
-            ('x-client-request-id', str(uuid.uuid4())),
+            (CLIENT_REQUEST_ID_METADATA_KEY, str(uuid.uuid4())),
         ]
         if self._enable_server_data_logging is not None:
             enable_server_data_logging = "true" if self._enable_server_data_logging else "false"

--- a/src/yandex_ai_studio_sdk/_exceptions.py
+++ b/src/yandex_ai_studio_sdk/_exceptions.py
@@ -7,6 +7,7 @@ from grpc.aio import AioRpcError as BaseAioRpcError
 from grpc.aio import Metadata
 
 from ._auth import BaseAuth
+from ._utils.metadata import CLIENT_REQUEST_ID_METADATA_KEY, extract_client_request_id
 
 if TYPE_CHECKING:
     # pylint: disable=cyclic-import
@@ -99,15 +100,11 @@ class AioRpcError(BaseAioRpcError):
         ):
             self._client_request_id = "grpc metadata was replaced with non-Metadata object"
         else:
-            client_request_id = (
-                initial and initial.get('x-client-request-id') or
-                trailing and trailing.get('x-client-request-id') or
+            self._client_request_id = (
+                extract_client_request_id(initial) or
+                extract_client_request_id(trailing) or
                 ""
             )
-            if isinstance(client_request_id, bytes):
-                self._client_request_id = client_request_id.decode('utf-8')
-            else:
-                self._client_request_id = client_request_id
 
     @classmethod
     def from_base_rpc_error(
@@ -138,7 +135,7 @@ class AioRpcError(BaseAioRpcError):
         ]
 
         if self._client_request_id:
-            parts.append(f'x-client-request-id = "{self._client_request_id}"')
+            parts.append(f'{CLIENT_REQUEST_ID_METADATA_KEY} = "{self._client_request_id}"')
 
         if self._code == StatusCode.UNAUTHENTICATED:
             auth = self._auth.__class__.__name__ if self._auth else None

--- a/src/yandex_ai_studio_sdk/_logging/interceptors.py
+++ b/src/yandex_ai_studio_sdk/_logging/interceptors.py
@@ -10,6 +10,7 @@ from yandex_ai_studio_sdk._utils.grpc import (
     RequestType, ResponseType, StreamReturnCallType, StreamStreamCallResponseIterator, UnaryReturnCallType,
     UnaryStreamCallResponseIterator, WrappedStreamReturnCallType
 )
+from yandex_ai_studio_sdk._utils.metadata import CLIENT_REQUEST_ID_METADATA_KEY, extract_client_request_id
 
 from .utils import get_logger
 
@@ -38,7 +39,8 @@ async def _log_from_call(
     call: Any,
     full_method: str,
     err: BaseException | None,
-    method_type: str
+    method_type: str,
+    request_id: str | None,
 ):
     service, method = split_full_method(full_method)
     metadata: dict[str, str] = {}
@@ -73,6 +75,10 @@ async def _log_from_call(
     if trailing:
         # pylint: disable-next=unnecessary-comprehension
         metadata = {key: value for key, value in trailing}
+    elif err is not None and request_id is not None:
+        metadata = {
+            CLIENT_REQUEST_ID_METADATA_KEY: request_id,
+        }
 
     logger.debug(
         "grpc client %s call service=%s method=%s code=%s details=%r metadata=%r",
@@ -88,9 +94,15 @@ async def _log_from_call(
 class UnaryReturnCallProxy(Generic[ResponseType]):
     method: str
 
-    def __init__(self, call: UnaryReturnCallType[RequestType, ResponseType], full_method: str):
+    def __init__(
+        self,
+        call: UnaryReturnCallType[RequestType, ResponseType],
+        full_method: str,
+        request_id: str | None,
+    ):
         self._call = call
         self._full_method = full_method
+        self._request_id = request_id
 
     def __getattr__(self, name):
         return getattr(self._call, name)
@@ -106,7 +118,11 @@ class UnaryReturnCallProxy(Generic[ResponseType]):
             raise
         finally:
             await _log_from_call(
-                call=self._call, full_method=self._full_method, err=err, method_type=self.method
+                call=self._call,
+                full_method=self._full_method,
+                err=err,
+                method_type=self.method,
+                request_id=self._request_id,
             )
 
     def __await__(self):
@@ -124,9 +140,15 @@ class _StreamUnaryCallProxy(UnaryReturnCallProxy):
 class StreamReturnCallProxy(Generic[RequestType, ResponseType]):
     method: str
 
-    def __init__(self, call: StreamReturnCallType[RequestType, ResponseType], full_method: str):
+    def __init__(
+        self,
+        call: StreamReturnCallType[RequestType, ResponseType],
+        full_method: str,
+        request_id: str | None,
+    ):
         self._call = call
         self._full_method = full_method
+        self._request_id = request_id
         self._logged = False
 
     def __getattr__(self, name):
@@ -146,7 +168,11 @@ class StreamReturnCallProxy(Generic[RequestType, ResponseType]):
             if not self._logged:
                 self._logged = True
                 await _log_from_call(
-                    call=self._call, full_method=self._full_method, err=err, method_type=self.method,
+                    call=self._call,
+                    full_method=self._full_method,
+                    err=err,
+                    method_type=self.method,
+                    request_id=self._request_id,
                 )
 
     def __aiter__(self):
@@ -164,25 +190,35 @@ class _StreamStreamCallProxy(StreamReturnCallProxy):
 class UnaryUnaryLogInterceptor(grpc.aio.UnaryUnaryClientInterceptor):
     async def intercept_unary_unary(self, continuation, client_call_details, request) -> ResponseType:
         call = await continuation(client_call_details, request)
-        return await _UnaryUnaryCallProxy(call, client_call_details.method)
+        request_id = extract_client_request_id(client_call_details.metadata)
+        return await _UnaryUnaryCallProxy(call, client_call_details.method, request_id)
 
 
 class UnaryStreamLogInterceptor(grpc.aio.UnaryStreamClientInterceptor):
     async def intercept_unary_stream(self, continuation, client_call_details, request) -> AsyncIterator[ResponseType]:
         call = await continuation(client_call_details, request)
-        return UnaryStreamCallResponseIterator(call, _UnaryStreamCallProxy(call, client_call_details.method))
+        request_id = extract_client_request_id(client_call_details.metadata)
+        return UnaryStreamCallResponseIterator(
+            call,
+            _UnaryStreamCallProxy(call, client_call_details.method, request_id),
+        )
 
 
 class StreamUnaryLogInterceptor(grpc.aio.StreamUnaryClientInterceptor):
     async def intercept_stream_unary(self, continuation, client_call_details, request_iterator) -> ResponseType:
         call = await continuation(client_call_details, request_iterator)
-        return await _StreamUnaryCallProxy(call, client_call_details.method)
+        request_id = extract_client_request_id(client_call_details.metadata)
+        return await _StreamUnaryCallProxy(call, client_call_details.method, request_id)
 
 
 class StreamStreamLogInterceptor(grpc.aio.StreamStreamClientInterceptor):
     async def intercept_stream_stream(self, continuation, client_call_details, request_iterator) -> AsyncIterator[ResponseType]:
         call = await continuation(client_call_details, request_iterator)
-        return StreamStreamCallResponseIterator(call, _StreamStreamCallProxy(call, client_call_details.method))
+        request_id = extract_client_request_id(client_call_details.metadata)
+        return StreamStreamCallResponseIterator(
+            call,
+            _StreamStreamCallProxy(call, client_call_details.method, request_id),
+        )
 
 
 def get_log_interceprtors():

--- a/src/yandex_ai_studio_sdk/_utils/metadata.py
+++ b/src/yandex_ai_studio_sdk/_utils/metadata.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Any
+
+CLIENT_REQUEST_ID_METADATA_KEY = 'x-client-request-id'
+
+
+def extract_client_request_id(metadata: Any) -> str | None:
+    if not metadata:
+        return None
+
+    # grpc.aio.Metadata is iterable over (key, value) pairs, so the same code
+    # also works for grpc metadata and tuple-like metadata containers.
+    try:
+        for key, value in metadata:
+            if key != CLIENT_REQUEST_ID_METADATA_KEY:
+                continue
+
+            if isinstance(value, bytes):
+                return value.decode('utf-8')
+            return value
+    except TypeError:
+        return None
+
+    return None

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import logging
+import time
 
+import grpc
 import pytest
 from yandex.cloud.ai.foundation_models.v1.text_common_pb2 import Token
 from yandex.cloud.ai.foundation_models.v1.text_generation.text_generation_service_pb2 import (
@@ -18,6 +20,15 @@ from yandex.cloud.ai.foundation_models.v1.text_generation.text_generation_servic
 def servicers():
     class TextGenerationServicer(TextGenerationServiceServicer):
         def Completion(self, request, context):
+            if request.messages[0].text == 'timeout':
+                time.sleep(0.2)
+                yield CompletionResponse(
+                    alternatives=[],
+                    usage=None,
+                    model_version='timeout'
+                )
+                return
+
             context.set_trailing_metadata((
                 ('key', 'value'),
             ))
@@ -29,6 +40,13 @@ def servicers():
 
     class TokenizerService(TokenizerServiceServicer):
         def TokenizeCompletion(self, request, context):
+            if request.messages[0].text == 'timeout':
+                time.sleep(0.2)
+                return TokenizeResponse(
+                    tokens=[],
+                    model_version="timeout"
+                )
+
             context.set_trailing_metadata((
                  ('key', 'value'),
             ))
@@ -41,6 +59,14 @@ def servicers():
         (TextGenerationServicer(), add_TextGenerationServiceServicer_to_server),
         (TokenizerService(), add_TokenizerServiceServicer_to_server),
     ]
+
+
+def assert_timeout_log_record(record):
+    assert 'code=StatusCode.DEADLINE_EXCEEDED' in record.getMessage()
+    assert record.args
+    metadata = record.args[-1]
+    assert isinstance(metadata, dict)
+    assert 'x-client-request-id' in metadata
 
 
 @pytest.mark.asyncio
@@ -65,6 +91,18 @@ async def test_logging_unary_unary(async_sdk, caplog):
 
 
 @pytest.mark.asyncio
+async def test_logging_unary_unary_timeout_request_id(async_sdk, caplog):
+    caplog.set_level(50)
+    caplog.set_level(logging.DEBUG, logger="yandex_ai_studio_sdk")
+
+    with pytest.raises(grpc.aio.AioRpcError, match='DEADLINE'):
+        await async_sdk.models.completions('foo').tokenize('timeout', timeout=0.05)
+
+    assert caplog.records
+    assert_timeout_log_record(caplog.records[0])
+
+
+@pytest.mark.asyncio
 async def test_logging_unary_stream(async_sdk, caplog):
     # sometimes there are strange asyncio+grpc ERROR log message about shutdown
     # and I'm too lazy to write a code here about selecting this test target log message
@@ -81,3 +119,15 @@ async def test_logging_unary_stream(async_sdk, caplog):
     metadata = record.args[-1]
     assert isinstance(metadata, dict)
     assert metadata['key'] == 'value'
+
+
+@pytest.mark.asyncio
+async def test_logging_unary_stream_timeout_request_id(async_sdk, caplog):
+    caplog.set_level(50)
+    caplog.set_level(logging.DEBUG, logger="yandex_ai_studio_sdk")
+
+    with pytest.raises(grpc.aio.AioRpcError, match='DEADLINE'):
+        await async_sdk.models.completions('foo').run('timeout', timeout=0.05)
+
+    assert caplog.records
+    assert_timeout_log_record(caplog.records[0])


### PR DESCRIPTION
Fixes #222.

## What changed

When gRPC debug logging was enabled and a request failed with `DEADLINE_EXCEEDED`,
the debug log could miss `x-client-request-id` because trailing metadata is not
always available in that scenario.

This PR preserves the request id in the timeout/error path without changing the
current logging behavior for successful calls.

## Implementation

- moved the `x-client-request-id` key into a shared metadata utility
- reused a common helper to extract the client request id from metadata
- added a fallback in gRPC debug logging so that when a request fails and trailing
  metadata is missing, the original request id is still logged
- kept the success path unchanged: successful calls still log server/trailing metadata

## Tests

Added timeout coverage for:
- unary-unary calls
- unary-stream calls

Also re-checked related request-id paths used by the client and exception handling.