### PR TITLE
Add playback progress tracking to AsyncAudioOut

### DIFF
--- a/src/yandex_ai_studio_sdk/_experimental/audio/out.py
+++ b/src/yandex_ai_studio_sdk/_experimental/audio/out.py
@@ -6,6 +6,13 @@ To use it: ``pip install sounddevice numpy``
 At Ubuntu also: ``sudo apt install libportaudio2``
 At Windows and MacOS PortAudio will be installed automagically.
 
+AsyncAudioOut tracks playback progress: ``played_ms`` is the duration of audio
+actually handed to the output device (padding silence excluded), ``written_ms``
+is the duration written so far. ``clear()`` drops the queued tail and returns
+the played duration. This makes honest barge-in handling possible in realtime
+voice agents: on interruption the caller knows exactly how much of the response
+the user heard (e.g. for ``conversation.item.truncate`` in the Realtime API).
+
 NB: AsyncAudioOut is not threadsafe!
 """
 
@@ -48,15 +55,31 @@ class AsyncAudioOut:
 
         self._stopped = asyncio.Event()
         self._loop: asyncio.AbstractEventLoop | None = None
-        self._queue: asyncio.Queue[np.ndarray | None] | None = None
+        self._queue: asyncio.Queue[tuple[np.ndarray, int] | None] | None = None
         self._stream: sd.OutputStream | None = None
         self._write_lock = asyncio.Lock()
         self._start_lock = asyncio.Lock()
+        # payload bytes only, padding silence excluded
+        self._played_bytes = 0
+        self._written_bytes = 0
 
     @property
     def queue_size(self) -> int:
         assert self._queue
         return self._queue.qsize()
+
+    @property
+    def played_ms(self) -> float:
+        """Duration of audio actually handed to the output device since open/last clear()."""
+        return self._bytes_to_ms(self._played_bytes)
+
+    @property
+    def written_ms(self) -> float:
+        """Duration of audio written via write() since open/last clear()."""
+        return self._bytes_to_ms(self._written_bytes)
+
+    def _bytes_to_ms(self, size: int) -> float:
+        return size / 2 / self._samplerate * 1000
 
     async def __aenter__(self) -> Self:
         async with self._start_lock:
@@ -65,6 +88,8 @@ class AsyncAudioOut:
 
             self._loop = asyncio.get_running_loop()
             self._queue = asyncio.Queue(MAX_QUEUE_SIZE)
+            self._played_bytes = 0
+            self._written_bytes = 0
             self._stream = sd.OutputStream(
                 samplerate=self._samplerate,
                 channels=1,
@@ -93,18 +118,29 @@ class AsyncAudioOut:
 
         assert self._loop
         try:
-            chunk = queue.get_nowait()
-            if chunk is None:
+            item = queue.get_nowait()
+            if item is None:
                 self._loop.call_soon_threadsafe(self._stopped.set)
                 return
 
+            chunk, payload_size = item
             outdata[:] = chunk
+            self._played_bytes += payload_size
         except asyncio.QueueEmpty:
             outdata.fill(0)
         return
 
-    async def clear(self):
+    async def clear(self) -> float:
+        """Drop queued audio and return how many ms were actually played.
+
+        Intended for barge-in: the return value is the exact duration the user
+        heard before the interruption.
+        """
+        played = self.played_ms
         self._queue = asyncio.Queue()
+        self._played_bytes = 0
+        self._written_bytes = 0
+        return played
 
     async def __aexit__(
         self,
@@ -148,7 +184,8 @@ class AsyncAudioOut:
                 end = min((payload_size, i + chunk_size))
                 chunk = pcm_16[i:end].ljust(chunk_size, b'\x00')
                 array = np.frombuffer(chunk, dtype=DTYPE)  # type: ignore[arg-type]
-                await queue.put(array.reshape(-1, 1))
+                await queue.put((array.reshape(-1, 1), end - i))
+            self._written_bytes += payload_size
 
 
 async def main() -> None:

--- a/src/yandex_ai_studio_sdk/_experimental/audio/out.py
+++ b/src/yandex_ai_studio_sdk/_experimental/audio/out.py
@@ -23,13 +23,14 @@ import types
 from typing import Any
 
 import numpy as np
-import sounddevice as sd
 from typing_extensions import Self
 
 try:
-    from .utils import choose_audio_device
-except ImportError:
-    from utils import choose_audio_device  # type: ignore[no-redef,import-not-found,attr-defined]
+    import sounddevice as sd
+except (ImportError, OSError):  # sounddevice also needs the PortAudio system library
+    # the module stays importable without sounddevice: it is only required
+    # to actually open the output stream
+    sd = None  # type: ignore[assignment]
 
 
 OUT_RATE = 44100
@@ -82,6 +83,10 @@ class AsyncAudioOut:
         return size / 2 / self._samplerate * 1000
 
     async def __aenter__(self) -> Self:
+        if sd is None:
+            raise RuntimeError(
+                'sounddevice is not available; see the module docstring for installation notes'
+            )
         async with self._start_lock:
             if self._loop:
                 raise RuntimeError('cannot use AsyncAudioOut simultaneously')
@@ -192,8 +197,10 @@ async def main() -> None:
     # pylint: disable=import-outside-toplevel
     try:
         from .microphone import AsyncMicrophone
+        from .utils import choose_audio_device
     except ImportError:
         from microphone import AsyncMicrophone  # type: ignore[no-redef,import-not-found,attr-defined]
+        from utils import choose_audio_device  # type: ignore[no-redef,import-not-found,attr-defined]
 
     mic_id = choose_audio_device('in')
     out_id = choose_audio_device('out')

--- a/tests/audio/test_out.py
+++ b/tests/audio/test_out.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 import asyncio
 import importlib
 import sys
-from typing import TYPE_CHECKING, AsyncIterator
+from typing import TYPE_CHECKING
+from collections.abc import AsyncIterator
 from unittest import mock
 
 import pytest

--- a/tests/audio/test_out.py
+++ b/tests/audio/test_out.py
@@ -2,43 +2,26 @@
 from __future__ import annotations
 
 import asyncio
-import importlib
-import sys
-from collections.abc import AsyncIterator
-from typing import TYPE_CHECKING
-from unittest import mock
 
 import pytest
 import pytest_asyncio
 
+from yandex_ai_studio_sdk._experimental.audio.out import AsyncAudioOut
+
 np = pytest.importorskip('numpy')
-
-if TYPE_CHECKING:
-    from yandex_ai_studio_sdk._experimental.audio.out import AsyncAudioOut
-
-OUT_MODULE = 'yandex_ai_studio_sdk._experimental.audio.out'
 
 SAMPLERATE = 44100
 BLOCKSIZE = 100
 
 
 @pytest_asyncio.fixture(name='out')
-async def out_fixture() -> AsyncIterator[AsyncAudioOut]:
-    """AsyncAudioOut with mocked sounddevice and a manually set up queue.
-
-    sounddevice needs the PortAudio system library even at import time and CI
-    has no audio devices; the tests below drive the queue and the callback
-    directly. The mock is scoped to the fixture and the cached module is
-    dropped afterwards, so nothing leaks into other test files.
-    """
-    sys.modules.pop(OUT_MODULE, None)
-    with mock.patch.dict(sys.modules, {'sounddevice': mock.MagicMock()}):
-        out_module = importlib.import_module(OUT_MODULE)
-        audio_out = out_module.AsyncAudioOut(samplerate=SAMPLERATE, blocksize=BLOCKSIZE)
-        audio_out._loop = asyncio.get_running_loop()
-        audio_out._queue = asyncio.Queue()
-        yield audio_out
-    sys.modules.pop(OUT_MODULE, None)
+async def out_fixture() -> AsyncAudioOut:
+    """AsyncAudioOut with the queue set up manually: no audio device or even
+    sounddevice needed — the tests drive the queue and the callback directly."""
+    out = AsyncAudioOut(samplerate=SAMPLERATE, blocksize=BLOCKSIZE)
+    out._loop = asyncio.get_running_loop()
+    out._queue = asyncio.Queue()
+    return out
 
 
 def drain_one_block(out: AsyncAudioOut) -> None:

--- a/tests/audio/test_out.py
+++ b/tests/audio/test_out.py
@@ -1,0 +1,74 @@
+# pylint: disable=protected-access
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+np = pytest.importorskip('numpy')
+pytest.importorskip('sounddevice')
+
+from yandex_ai_studio_sdk._experimental.audio.out import AsyncAudioOut  # noqa: E402
+
+
+def make_out(samplerate: int = 44100, blocksize: int = 100) -> AsyncAudioOut:
+    """AsyncAudioOut with the queue set up manually: no real audio device needed."""
+    out = AsyncAudioOut(samplerate=samplerate, blocksize=blocksize)
+    out._loop = asyncio.get_running_loop()
+    out._queue = asyncio.Queue()
+    return out
+
+
+def drain_one_block(out: AsyncAudioOut, blocksize: int = 100) -> None:
+    """Simulate the PortAudio callback consuming one block from the queue."""
+    outdata = np.zeros((blocksize, 1), dtype='int16')
+    out._callback(outdata, blocksize, None, None)
+
+
+@pytest.mark.asyncio
+async def test_played_ms_counts_only_played_payload():
+    out = make_out()
+    # 3 blocks of 100 samples; 100 samples at 44100 Hz int16 = 200 bytes
+    await out.write(b'\x01\x02' * 300)
+    assert out.written_ms == pytest.approx(300 / 44100 * 1000)
+    assert out.played_ms == 0
+
+    drain_one_block(out)
+    assert out.played_ms == pytest.approx(100 / 44100 * 1000)
+
+    drain_one_block(out)
+    drain_one_block(out)
+    assert out.played_ms == pytest.approx(out.written_ms)
+
+    # queue is empty: callback outputs silence, played_ms must not grow
+    drain_one_block(out)
+    assert out.played_ms == pytest.approx(out.written_ms)
+
+
+@pytest.mark.asyncio
+async def test_padding_silence_is_not_counted():
+    out = make_out()
+    # 150 samples: one full block and one half-filled block padded with silence
+    await out.write(b'\x01\x02' * 150)
+
+    drain_one_block(out)
+    drain_one_block(out)
+    assert out.played_ms == pytest.approx(150 / 44100 * 1000)
+
+
+@pytest.mark.asyncio
+async def test_clear_returns_played_and_resets():
+    out = make_out()
+    await out.write(b'\x01\x02' * 300)
+    drain_one_block(out)
+
+    played = await out.clear()
+    assert played == pytest.approx(100 / 44100 * 1000)
+    assert out.played_ms == 0
+    assert out.written_ms == 0
+    assert out.queue_size == 0
+
+    # writing after clear starts a fresh count
+    await out.write(b'\x01\x02' * 100)
+    drain_one_block(out)
+    assert out.played_ms == pytest.approx(100 / 44100 * 1000)

--- a/tests/audio/test_out.py
+++ b/tests/audio/test_out.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 import asyncio
 import importlib
 import sys
-from typing import TYPE_CHECKING
 from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest

--- a/tests/audio/test_out.py
+++ b/tests/audio/test_out.py
@@ -2,39 +2,49 @@
 from __future__ import annotations
 
 import asyncio
+import sys
+from unittest.mock import MagicMock
 
 import pytest
+import pytest_asyncio
 
 np = pytest.importorskip('numpy')
-pytest.importorskip('sounddevice')
+
+# sounddevice needs the PortAudio system library even at import time and CI has
+# no audio devices; the tests below drive the queue and the callback directly,
+# so the module is mocked out entirely
+sys.modules.setdefault('sounddevice', MagicMock())
 
 from yandex_ai_studio_sdk._experimental.audio.out import AsyncAudioOut  # noqa: E402
 
+SAMPLERATE = 44100
+BLOCKSIZE = 100
 
-def make_out(samplerate: int = 44100, blocksize: int = 100) -> AsyncAudioOut:
+
+@pytest_asyncio.fixture(name='out')
+async def out_fixture() -> AsyncAudioOut:
     """AsyncAudioOut with the queue set up manually: no real audio device needed."""
-    out = AsyncAudioOut(samplerate=samplerate, blocksize=blocksize)
+    out = AsyncAudioOut(samplerate=SAMPLERATE, blocksize=BLOCKSIZE)
     out._loop = asyncio.get_running_loop()
     out._queue = asyncio.Queue()
     return out
 
 
-def drain_one_block(out: AsyncAudioOut, blocksize: int = 100) -> None:
+def drain_one_block(out: AsyncAudioOut) -> None:
     """Simulate the PortAudio callback consuming one block from the queue."""
-    outdata = np.zeros((blocksize, 1), dtype='int16')
-    out._callback(outdata, blocksize, None, None)
+    outdata = np.zeros((BLOCKSIZE, 1), dtype='int16')
+    out._callback(outdata, BLOCKSIZE, None, None)
 
 
 @pytest.mark.asyncio
-async def test_played_ms_counts_only_played_payload():
-    out = make_out()
+async def test_played_ms_counts_only_played_payload(out):
     # 3 blocks of 100 samples; 100 samples at 44100 Hz int16 = 200 bytes
     await out.write(b'\x01\x02' * 300)
-    assert out.written_ms == pytest.approx(300 / 44100 * 1000)
+    assert out.written_ms == pytest.approx(300 / SAMPLERATE * 1000)
     assert out.played_ms == 0
 
     drain_one_block(out)
-    assert out.played_ms == pytest.approx(100 / 44100 * 1000)
+    assert out.played_ms == pytest.approx(100 / SAMPLERATE * 1000)
 
     drain_one_block(out)
     drain_one_block(out)
@@ -46,24 +56,22 @@ async def test_played_ms_counts_only_played_payload():
 
 
 @pytest.mark.asyncio
-async def test_padding_silence_is_not_counted():
-    out = make_out()
+async def test_padding_silence_is_not_counted(out):
     # 150 samples: one full block and one half-filled block padded with silence
     await out.write(b'\x01\x02' * 150)
 
     drain_one_block(out)
     drain_one_block(out)
-    assert out.played_ms == pytest.approx(150 / 44100 * 1000)
+    assert out.played_ms == pytest.approx(150 / SAMPLERATE * 1000)
 
 
 @pytest.mark.asyncio
-async def test_clear_returns_played_and_resets():
-    out = make_out()
+async def test_clear_returns_played_and_resets(out):
     await out.write(b'\x01\x02' * 300)
     drain_one_block(out)
 
     played = await out.clear()
-    assert played == pytest.approx(100 / 44100 * 1000)
+    assert played == pytest.approx(100 / SAMPLERATE * 1000)
     assert out.played_ms == 0
     assert out.written_ms == 0
     assert out.queue_size == 0
@@ -71,4 +79,4 @@ async def test_clear_returns_played_and_resets():
     # writing after clear starts a fresh count
     await out.write(b'\x01\x02' * 100)
     drain_one_block(out)
-    assert out.played_ms == pytest.approx(100 / 44100 * 1000)
+    assert out.played_ms == pytest.approx(100 / SAMPLERATE * 1000)

--- a/tests/audio/test_out.py
+++ b/tests/audio/test_out.py
@@ -2,32 +2,42 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 import sys
-from unittest.mock import MagicMock
+from typing import TYPE_CHECKING, AsyncIterator
+from unittest import mock
 
 import pytest
 import pytest_asyncio
 
 np = pytest.importorskip('numpy')
 
-# sounddevice needs the PortAudio system library even at import time and CI has
-# no audio devices; the tests below drive the queue and the callback directly,
-# so the module is mocked out entirely
-sys.modules.setdefault('sounddevice', MagicMock())
+if TYPE_CHECKING:
+    from yandex_ai_studio_sdk._experimental.audio.out import AsyncAudioOut
 
-from yandex_ai_studio_sdk._experimental.audio.out import AsyncAudioOut  # noqa: E402  # pylint: disable=wrong-import-position
+OUT_MODULE = 'yandex_ai_studio_sdk._experimental.audio.out'
 
 SAMPLERATE = 44100
 BLOCKSIZE = 100
 
 
 @pytest_asyncio.fixture(name='out')
-async def out_fixture() -> AsyncAudioOut:
-    """AsyncAudioOut with the queue set up manually: no real audio device needed."""
-    out = AsyncAudioOut(samplerate=SAMPLERATE, blocksize=BLOCKSIZE)
-    out._loop = asyncio.get_running_loop()
-    out._queue = asyncio.Queue()
-    return out
+async def out_fixture() -> AsyncIterator[AsyncAudioOut]:
+    """AsyncAudioOut with mocked sounddevice and a manually set up queue.
+
+    sounddevice needs the PortAudio system library even at import time and CI
+    has no audio devices; the tests below drive the queue and the callback
+    directly. The mock is scoped to the fixture and the cached module is
+    dropped afterwards, so nothing leaks into other test files.
+    """
+    sys.modules.pop(OUT_MODULE, None)
+    with mock.patch.dict(sys.modules, {'sounddevice': mock.MagicMock()}):
+        out_module = importlib.import_module(OUT_MODULE)
+        audio_out = out_module.AsyncAudioOut(samplerate=SAMPLERATE, blocksize=BLOCKSIZE)
+        audio_out._loop = asyncio.get_running_loop()
+        audio_out._queue = asyncio.Queue()
+        yield audio_out
+    sys.modules.pop(OUT_MODULE, None)
 
 
 def drain_one_block(out: AsyncAudioOut) -> None:

--- a/tests/audio/test_out.py
+++ b/tests/audio/test_out.py
@@ -15,7 +15,7 @@ np = pytest.importorskip('numpy')
 # so the module is mocked out entirely
 sys.modules.setdefault('sounddevice', MagicMock())
 
-from yandex_ai_studio_sdk._experimental.audio.out import AsyncAudioOut  # noqa: E402
+from yandex_ai_studio_sdk._experimental.audio.out import AsyncAudioOut  # noqa: E402  # pylint: disable=wrong-import-position
 
 SAMPLERATE = 44100
 BLOCKSIZE = 100


### PR DESCRIPTION
`AsyncAudioOut` now tracks how much audio was actually played: new `played_ms` / `written_ms` properties, and `clear()` returns the played duration (padding silence excluded).

This enables honest barge-in handling in realtime voice agents: on interruption the caller knows exactly how much of the response the user heard, e.g. for `conversation.item.truncate`:

```python
heard_ms = await audio_out.clear()  # user interrupted
```

Backwards compatible.

