### PR TITLE
feat: add per-attempt retry timeout

### DIFF
--- a/src/yandex_ai_studio_sdk/_retry.py
+++ b/src/yandex_ai_studio_sdk/_retry.py
@@ -108,7 +108,17 @@ class RetrierBase:
 
                 code = e.code()
 
-                if code not in self._policy.retriable_codes:
+                # A deadline caused by the per-attempt timeout is retryable while
+                # there is still time left in the overall request budget.  An
+                # exhausted overall deadline keeps its previous terminal
+                # behaviour.
+                attempt_deadline_exceeded = (
+                    code == grpc.StatusCode.DEADLINE_EXCEEDED
+                    and self._policy.attempt_timeout is not None
+                    and (deadline is None or time.time() < deadline)
+                )
+
+                if code not in self._policy.retriable_codes and not attempt_deadline_exceeded:
                     raise
 
                 await self._policy.sleep(attempt, deadline)
@@ -153,12 +163,20 @@ class RetrierBase:
         if attempt > 0:
             assert client_call_details.metadata is not None  # it is always is not None because of our client
             client_call_details.metadata[self._ATTEMPT_METADATA_KEY] = str(attempt)
-            if deadline is not None:
-                new_timeout = max((deadline - time.time(), 0))
 
-                # client_call_details is the namedtuple but apparently this nuance is lacking from
-                # grpc-stubs package
-                client_call_details = client_call_details._replace(timeout=new_timeout)  # type: ignore[attr-defined]
+        remaining_timeout = max((deadline - time.time(), 0)) if deadline is not None else None
+        attempt_timeout = self._policy.attempt_timeout
+        new_timeout: float | None
+
+        if attempt_timeout is not None:
+            new_timeout = min(attempt_timeout, remaining_timeout) if remaining_timeout is not None else attempt_timeout
+        else:
+            new_timeout = remaining_timeout
+
+        if new_timeout is not None and (attempt > 0 or attempt_timeout is not None):
+            # client_call_details is the namedtuple but apparently this nuance is lacking from
+            # grpc-stubs package
+            client_call_details = client_call_details._replace(timeout=new_timeout)  # type: ignore[attr-defined]
 
         call = await continuation(client_call_details, request)
 
@@ -242,6 +260,9 @@ class RetryPolicy:
     backoff_multiplier: float = 1.5
     #: the maximum amount of jitter to add to the backoff
     jitter: float = 1.0
+    #: maximum duration of a single attempt in seconds; ``None`` means that an
+    #: attempt may use the whole remaining request timeout
+    attempt_timeout: float | None = None
     #: the grpc status codes that are considered retriable
     retriable_codes: Iterable[grpc.StatusCode] = (
         grpc.StatusCode.UNAVAILABLE,
@@ -251,6 +272,10 @@ class RetryPolicy:
     unary_unary_interceptor_class: type[UnaryUnaryRetryInterceptor] | None = UnaryUnaryRetryInterceptor
     #: :meta private:
     unary_stream_interceptor_class: type[UnaryStreamRetryInterceptor] | None = UnaryStreamRetryInterceptor
+
+    def __post_init__(self) -> None:
+        if self.attempt_timeout is not None and self.attempt_timeout <= 0:
+            raise ValueError("attempt_timeout must be greater than zero")
 
     def get_interceptors(self) -> tuple[grpc.aio.ClientInterceptor, ...]:
         klasses = [self.unary_unary_interceptor_class, self.unary_stream_interceptor_class]

--- a/tests/test_retries.py
+++ b/tests/test_retries.py
@@ -18,8 +18,8 @@ from yandex_ai_studio_sdk.retry import RetryPolicy
 
 
 @pytest.fixture(name='retry_policy')
-def fixture_retry_policy() -> RetryPolicy:
-    return RetryPolicy(jitter=0, max_backoff=1.5)
+def fixture_retry_policy(request) -> RetryPolicy:
+    return getattr(request, 'param', RetryPolicy(jitter=0, max_backoff=1.5))
 
 
 @pytest.fixture
@@ -59,8 +59,19 @@ def servicers():
     class TokenizerService(TokenizerServiceServicer):
         def __init__(self):
             self.i = 0
+            self.slow_i = 0
 
         def TokenizeCompletion(self, request, context):
+            if request.messages[0].text == 'slow-first-attempt':
+                self.slow_i += 1
+                if self.slow_i == 1:
+                    time.sleep(0.25)
+
+                return TokenizeResponse(
+                    tokens=[Token(id=2, text='retried', special=False)],
+                    model_version='attempt-timeout'
+                )
+
             self.i += 1
             time.sleep(0.1)
 
@@ -133,3 +144,37 @@ async def test_retry_deadline(async_sdk):
         await async_sdk.models.completions('foo').run('bar', timeout=1)
     retry_delta = time.time() - initial_time
     assert 1 <= retry_delta < 2
+
+
+@pytest.mark.parametrize(
+    'retry_policy',
+    [
+        RetryPolicy(
+            max_attempts=3,
+            initial_backoff=0,
+            max_backoff=0,
+            jitter=0,
+            attempt_timeout=0.05,
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_retry_attempt_timeout(async_sdk):
+    initial_time = time.monotonic()
+    result = await async_sdk.models.completions('foo').tokenize(
+        'slow-first-attempt',
+        timeout=1,
+    )
+    retry_delta = time.monotonic() - initial_time
+
+    assert result[0].text == 'retried'
+    assert result[0].id == 2
+    assert result[0].special is False
+    assert retry_delta < 0.5
+
+
+@pytest.mark.parametrize('attempt_timeout', [0, -1])
+def test_retry_attempt_timeout_must_be_positive(attempt_timeout):
+    with pytest.raises(ValueError, match='attempt_timeout must be greater than zero'):
+        RetryPolicy(attempt_timeout=attempt_timeout)


### PR DESCRIPTION
# Add a per-attempt timeout to retry policy

Closes #216.

## Problem

The request `timeout` currently covers the complete retry lifecycle. A single
slow attempt can therefore consume the entire budget before another attempt is
started.

## Proposed API

```python
RetryPolicy(attempt_timeout=5.0)
```

`attempt_timeout=None` remains the default and preserves current behavior. When
configured, the effective timeout of every attempt is:

```text
min(attempt_timeout, remaining overall request timeout)
```

`DEADLINE_EXCEEDED` is retried only when an attempt timeout is configured and
the overall deadline still has budget. Exhausting the overall deadline remains
terminal.

## Tests

- a first unary request sleeps longer than `attempt_timeout`;
- the second request succeeds inside the overall timeout;
- the existing overall-deadline test remains unchanged;
- zero and negative `attempt_timeout` values are rejected.

Local verification:

```text
tests/test_retries.py                  6 passed
full test suite                        233 passed, 21 skipped, 2 xfailed
pylint changed files                  8 passed
mypy changed files                    9 passed; no issues
all pre-commit hooks                   passed
```

## Review questions

1. Is `RetryPolicy.attempt_timeout` the preferred public surface, or should the
   value be request-specific?
2. Should a server-originated `DEADLINE_EXCEEDED` be distinguished from the
   local attempt deadline, if the transport exposes enough information?
3. Should the same semantic be added to HTTP/SSE paths in this PR or kept as a
   follow-up after the gRPC contract is accepted?

The implementation intentionally does not add `DEADLINE_EXCEEDED` to the global
default `retriable_codes`: it is retryable only under the explicit per-attempt
policy while overall time remains.
